### PR TITLE
feat: add reusable AWS ECR container build workflow

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -1,0 +1,58 @@
+on:
+  workflow_call:
+    inputs:
+      region:
+        type: string
+        required: true
+      repository_name:
+        type: string
+        required: true
+      aws_account_id:
+        type: string
+        required: true
+      role_to_assume:
+        type: string
+        required: true
+      platforms:
+        type: string
+        required: false
+        default: linux/arm64,linux/amd64
+      lfs:
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      go_github_username:
+        required: false
+      go_github_token:
+        required: false
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 10
+          fetch-tags: true
+          lfs: ${{ inputs.lfs }}
+      - name: Tag
+        uses: martoc/action-tag@v0
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.role_to_assume }}
+          role-session-name: github-actions
+          aws-region: ${{ inputs.region }}
+      - name: Container Build
+        uses: martoc/action-container-build@v0
+        with:
+          registry: aws
+          platforms: ${{ inputs.platforms }}
+          region: ${{ inputs.region }}
+          repository_name: ${{ inputs.repository_name }}
+          aws_account_id: ${{ inputs.aws_account_id }}
+          build_args: --build-arg GO_GITHUB_USERNAME=${{ secrets.go_github_username }} --build-arg GO_GITHUB_TOKEN=${{ secrets.go_github_token }}
+      - name: Release on GitHub
+        uses: martoc/action-release@v0
+        if: ${{ github.event_name != 'pull_request' }}

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 # workflow-container-image
 
-Reusable GitHub Actions workflows for building and publishing container images to Docker Hub and GCP Artifact Registry.
+Reusable GitHub Actions workflows for building and publishing container images to Docker Hub, AWS ECR, and GCP Artifact Registry.
 
 ## Features
 
 - Multi-platform builds (linux/arm64, linux/amd64)
-- Docker Hub and GCP Artifact Registry support
+- Docker Hub, AWS ECR, and GCP Artifact Registry support
 - Automatic semantic versioning with `action-tag`
 - GitHub release creation
 - Git LFS support
@@ -22,6 +22,23 @@ jobs:
     permissions:
       contents: write
     uses: martoc/workflow-container-image/.github/workflows/default.yml@v0
+    secrets: inherit
+```
+
+### AWS ECR
+
+```yaml
+jobs:
+  build:
+    permissions:
+      contents: write
+      id-token: write
+    uses: martoc/workflow-container-image/.github/workflows/aws.yml@v0
+    with:
+      region: us-east-2
+      repository_name: my-repo
+      aws_account_id: "123456789012"
+      role_to_assume: arn:aws:iam::123456789012:role/github-actions
     secrets: inherit
 ```
 
@@ -53,6 +70,7 @@ jobs:
 | Workflow | Registry | Description |
 |----------|----------|-------------|
 | `default.yml` | Docker Hub | Build and push to Docker Hub |
+| `aws.yml` | AWS ECR | Build and push to AWS ECR |
 | `gcp.yml` | GCP Artifact Registry | Build and push to GCP |
 
 ## Licence

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -41,6 +41,51 @@ jobs:
     secrets: inherit
 ```
 
+### aws.yml
+
+Builds and pushes container images to AWS Elastic Container Registry (ECR).
+
+**Inputs:**
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `region` | string | Yes | - | AWS region (e.g., `us-east-2`, `eu-west-1`) |
+| `repository_name` | string | Yes | - | ECR repository name |
+| `aws_account_id` | string | Yes | - | AWS Account ID (12-digit) |
+| `role_to_assume` | string | Yes | - | ARN of the IAM role to assume via OIDC |
+| `platforms` | string | No | `linux/arm64,linux/amd64` | Target platforms for build |
+| `lfs` | boolean | No | `false` | Enable Git LFS for checkout |
+
+**Optional Secrets:**
+
+- `go_github_username` - GitHub username for Go private modules
+- `go_github_token` - GitHub token for Go private modules
+
+**Example:**
+
+```yaml
+name: Build Container
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    permissions:
+      contents: write
+      id-token: write
+    uses: martoc/workflow-container-image/.github/workflows/aws.yml@v0
+    with:
+      region: us-east-2
+      repository_name: my-repo
+      aws_account_id: "123456789012"
+      role_to_assume: arn:aws:iam::123456789012:role/github-actions
+    secrets: inherit
+```
+
 ### gcp.yml
 
 Builds and pushes container images to GCP Artifact Registry.


### PR DESCRIPTION
## Summary

- Add `aws.yml` reusable workflow for building and pushing container images to AWS ECR
- Uses `aws-actions/configure-aws-credentials@v4` for OIDC authentication
- Follows the same pattern as the existing `gcp.yml` workflow
- Accepts `region`, `repository_name`, `aws_account_id`, and `role_to_assume` as inputs
- Update README and USAGE documentation with inputs, secrets, and usage examples

## Test plan

- [ ] Test the reusable workflow from a consumer repository by referencing this branch
- [ ] Validate OIDC credential flow with a configured AWS IAM role
- [ ] Verify container image is pushed to ECR with correct tags and labels