### PR TITLE
fix: upgrade actions to versions supporting Node 24

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 10
           fetch-tags: true
@@ -39,7 +39,7 @@ jobs:
       - name: Tag
         uses: martoc/action-tag@v0
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ inputs.role_to_assume }}
           role-session-name: github-actions

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 10
           fetch-tags: true

--- a/.github/workflows/gcp.yml
+++ b/.github/workflows/gcp.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 10
           fetch-tags: true


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4 → v6 in `.github/workflows/{default,aws,gcp}.yml`
- Bump `aws-actions/configure-aws-credentials` v4 → v6 in `.github/workflows/aws.yml`

## Why

GitHub Actions has deprecated Node.js 20 (see [deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). From 2 June 2026, affected actions will be forced onto Node.js 24; Node.js 20 is removed from the runner on 16 September 2026. The bumped versions run on Node.js 24 by default.

## Test plan

- [ ] CI checks pass
- [ ] Reusable workflow callers continue to build container images successfully
