### PR TITLE
fix: thread name override through to action-container-build

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -9,6 +9,10 @@ on:
         type: string
         required: false
         default: linux/arm64,linux/amd64
+      name:
+        type: string
+        required: false
+        default: ""
 jobs:
   build:
     runs-on: ubuntu-24.04
@@ -25,6 +29,7 @@ jobs:
         uses: martoc/action-container-build@v0
         with:
           platforms: ${{ inputs.platforms }}
+          name: ${{ inputs.name }}
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
## Summary
- Add an optional `name` input and thread it through to `martoc/action-container-build`'s new `name` override.

## Why
Part of fixing the image-name drift where `mcp-vanguard-portafolio` publishes under the wrong Docker Hub repo name. Requires `martoc/action-container-build@v0` to already support the `name` input (merged: https://github.com/martoc/action-container-build/pull/18).

## Test plan
- [ ] Merge and confirm `v0` tag updates
- [ ] Set `name: vanguard-mcp-server` in `mcp-vanguard-portafolio`'s workflow call
- [ ] Verify `martoc/vanguard-mcp-server:latest` updates on Docker Hub
